### PR TITLE
skip integration tests when -short flag is provided

### DIFF
--- a/cmd/test/check_execution_test.go
+++ b/cmd/test/check_execution_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestCheckExecutionViaCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
 	var blockInterval int64
 	blockInterval = 5
 

--- a/cmd/test/create_cookbook_test.go
+++ b/cmd/test/create_cookbook_test.go
@@ -15,6 +15,10 @@ type CreateCookbookMsgValueModel struct {
 }
 
 func TestCreateCookbookViaCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
 	tests := []struct {
 		name string
 	}{

--- a/cmd/test/create_recipe_test.go
+++ b/cmd/test/create_recipe_test.go
@@ -18,6 +18,10 @@ type CreateRecipeMsgValueModel struct {
 }
 
 func TestCreateRecipeViaCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
 	err := MockCookbook(t)
 	if err != nil {
 		t.Errorf("error mocking cookbook %+v", err)

--- a/cmd/test/execute_recipe_test.go
+++ b/cmd/test/execute_recipe_test.go
@@ -9,6 +9,10 @@ import (
 )
 
 func TestExecuteRecipeViaCLI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
 	err := MockCookbook(t)
 	if err != nil {
 		t.Errorf("error mocking cookbook %+v", err)

--- a/cmd/test/list_recipes_test.go
+++ b/cmd/test/list_recipes_test.go
@@ -7,6 +7,11 @@ import (
 )
 
 func TestListRecipeViaCLI(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
 	err := MockCookbook(t)
 	if err != nil {
 		t.Errorf("error mocking cookbook %+v", err)


### PR DESCRIPTION
Sometimes locally developers want to skip integration tests and hence providing support for `-short` flag.

So now `go test -short ./...` will skip the integration tests