### PR TITLE
case to verify Generate()

### DIFF
--- a/x/pylons/types/int_weight_table_test.go
+++ b/x/pylons/types/int_weight_table_test.go
@@ -1,0 +1,20 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntWeightTable_NoRandomization(t *testing.T) {
+	iwt := IntWeightTable{
+		WeightRanges: []IntWeightRange{
+			IntWeightRange{
+				Lower:  100,
+				Upper:  101,
+				Weight: 1,
+			},
+		},
+	}
+	require.True(t, iwt.Generate() == 100)
+}


### PR DESCRIPTION
This test case verifies keeping upper and lower bound at a difference of 1 and weight to 1 to cancel randomization