### PR TITLE
extracted common code from enable and disable recipe into utils

### DIFF
--- a/x/pylons/handlers/custom_ante_handler.go
+++ b/x/pylons/handlers/custom_ante_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"encoding/base64"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -178,12 +177,6 @@ func processSig(
 	if !res.IsOK() {
 		return nil, res
 	}
-	fmt.Println("address", sdk.AccAddress(pubKey.Address().Bytes()).String())
-	fmt.Println("signBytes", string(signBytes))
-	fmt.Println("signature", base64.StdEncoding.EncodeToString(sig.Signature))
-	fmt.Println("chainID", ctx.ChainID())
-	fmt.Println("account Number", acc.GetAccountNumber())
-	fmt.Println("sig match", pubKey.VerifyBytes(signBytes, sig.Signature))
 	err := acc.SetPubKey(pubKey)
 	if err != nil {
 		return nil, sdk.ErrInternal("setting PubKey on signer's account").Result()

--- a/x/pylons/handlers/disable_recipe.go
+++ b/x/pylons/handlers/disable_recipe.go
@@ -1,10 +1,9 @@
 package handlers
 
 import (
-	"encoding/json"
-
 	"github.com/MikeSofaer/pylons/x/pylons/keep"
 	"github.com/MikeSofaer/pylons/x/pylons/msgs"
+	"github.com/MikeSofaer/pylons/x/pylons/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -16,36 +15,13 @@ type DisableRecipeResp struct {
 
 // HandlerMsgDisableRecipe is used to disable recipe by a developer
 func HandlerMsgDisableRecipe(ctx sdk.Context, keeper keep.Keeper, msg msgs.MsgDisableRecipe) sdk.Result {
-
 	err := msg.ValidateBasic()
 	if err != nil {
 		return err.Result()
 	}
-
-	recipe, err2 := keeper.GetRecipe(ctx, msg.RecipeID)
-	if err2 != nil {
-		return errInternal(err2)
-	}
-
-	if !msg.Sender.Equals(recipe.Sender) {
-		return sdk.ErrUnauthorized("msg sender is not the owner of the recipe").Result()
-	}
-	recipe.Disabled = true
-
-	err2 = keeper.UpdateRecipe(ctx, msg.RecipeID, recipe)
-	if err2 != nil {
-		return errInternal(err2)
-	}
-
-	resp, err2 := json.Marshal(DisableRecipeResp{
-		Message: "successfully disabled the recipe",
-		Status:  "Success",
+	return recipeChangeContext(ctx, keeper, msg.RecipeID, msg.Sender, func(recipe *types.Recipe) error {
+		// we disable the recipe
+		recipe.Disabled = true
+		return nil
 	})
-
-	if err2 != nil {
-		return errInternal(err2)
-
-	}
-
-	return sdk.Result{Data: resp}
 }

--- a/x/pylons/handlers/disable_recipe_test.go
+++ b/x/pylons/handlers/disable_recipe_test.go
@@ -73,7 +73,7 @@ func TestHandlerMsgDisableRecipe(t *testing.T) {
 
 				require.True(t, err == nil)
 				require.True(t, disableRcpResponse.Status == "Success")
-				require.True(t, disableRcpResponse.Message == "successfully disabled the recipe")
+				require.True(t, disableRcpResponse.Message == "successfully changed the recipe")
 
 				uRcp, err2 := mockedCoinInput.PlnK.GetRecipe(mockedCoinInput.Ctx, tc.recipeID)
 				// t.Errorf("DisableRecipeTEST LOG:: %+v", uRcp)

--- a/x/pylons/handlers/enable_recipe_test.go
+++ b/x/pylons/handlers/enable_recipe_test.go
@@ -70,13 +70,12 @@ func TestHandlerMsgEnableRecipe(t *testing.T) {
 
 				require.True(t, err == nil)
 				require.True(t, enableRcpResponse.Status == "Success")
-				require.True(t, enableRcpResponse.Message == "successfully enabled the recipe")
+				require.True(t, enableRcpResponse.Message == "successfully changed the recipe")
 
 				uRcp, err2 := mockedCoinInput.PlnK.GetRecipe(mockedCoinInput.Ctx, tc.recipeID)
 				require.True(t, err2 == nil)
 				require.True(t, uRcp.Disabled == false)
 			} else {
-				// t.Errorf("EnableRecipeTEST LOG:: %+v", result)
 				require.True(t, strings.Contains(result.Log, tc.desiredError))
 			}
 		})

--- a/x/pylons/handlers/utils.go
+++ b/x/pylons/handlers/utils.go
@@ -1,8 +1,46 @@
 package handlers
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	"encoding/json"
+
+	"github.com/MikeSofaer/pylons/x/pylons/keep"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 func errInternal(err error) sdk.Result {
 
 	return sdk.ErrInternal(err.Error()).Result()
+}
+
+func recipeChangeContext(ctx sdk.Context, keeper keep.Keeper, recipeID string, msgSender sdk.AccAddress, recipeFn RecipeChangeFn) sdk.Result {
+
+	recipe, err2 := keeper.GetRecipe(ctx, recipeID)
+	if err2 != nil {
+		return errInternal(err2)
+	}
+
+	if !msgSender.Equals(recipe.Sender) {
+		return sdk.ErrUnauthorized("msg sender is not the owner of the recipe").Result()
+	}
+
+	err2 = recipeFn(&recipe)
+	if err2 != nil {
+		return errInternal(err2)
+	}
+
+	err2 = keeper.UpdateRecipe(ctx, recipeID, recipe)
+	if err2 != nil {
+		return errInternal(err2)
+	}
+
+	resp, err2 := json.Marshal(EnableRecipeResp{
+		Message: "successfully changed the recipe",
+		Status:  "Success",
+	})
+
+	if err2 != nil {
+		return errInternal(err2)
+	}
+
+	return sdk.Result{Data: resp}
 }


### PR DESCRIPTION
This PR drys the code and the helper function `recipeChangeContext` can be used at many other places.
Also removed print statements from the custom_ante_handler