### PR TITLE
fix concurrent map read and map write for fixture test precondition checker

### DIFF
--- a/cmd/fixtures_test/README.md
+++ b/cmd/fixtures_test/README.md
@@ -52,6 +52,14 @@ Detailed params can be found at `./scenarios/submarine.json`.
 And to make things easier and to make scenario file smaller, there are references to other files.
 For example when creating recipe, recipe spec is in `./recipes` folder.
 
+hint.  
+To ignore txResult Message, which is because it's ambitious to get which message to get, can just ignore TxResult.Message field like below.
+```
+    "txResult": {
+        "status": "Success"
+    },
+```
+
 ## How a game producer write test 
 
 Before reading this, he/she should know well about pylons eco system. Please read [DEVELOPER DOC](https://github.com/MikeSofaer/pylons/blob/master/DEVELOPER_DOC.md) and [README](https://github.com/MikeSofaer/pylons/blob/master/README.md) before reading this.

--- a/cmd/fixtures_test/scenario_validation.go
+++ b/cmd/fixtures_test/scenario_validation.go
@@ -9,15 +9,12 @@ import (
 // Algorithm link geeksforgeeks.org/detect-cycle-in-a-graph/
 
 var VMap map[string]int = make(map[string]int) // StepID to GraphID mapper
-var VMapMutex = sync.RWMutex{}
+var VMapMutex = sync.Mutex{}
 var NV = 0 // Number of steps
 var adj [][]int
-var adjMutex = sync.RWMutex{}
 
 // This is to convert string to into for circular check algorithm
 func AddVertice(VSID string) bool {
-	VMapMutex.Lock()
-	adjMutex.Lock()
 	if _, ok := VMap[VSID]; !ok {
 		VMap[VSID] = NV
 		if NV == 0 {
@@ -29,13 +26,10 @@ func AddVertice(VSID string) bool {
 		NV = NV + 1
 		return true
 	}
-	VMapMutex.Unlock()
-	adjMutex.Unlock()
 	return false
 }
 
 func AddEdge(VSID, WSID string) bool {
-	VMapMutex.RLock()
 	if _, ok := VMap[VSID]; !ok {
 		return false
 	}
@@ -44,11 +38,8 @@ func AddEdge(VSID, WSID string) bool {
 	}
 	v := VMap[VSID]
 	w := VMap[WSID]
-	VMapMutex.RUnlock()
 
-	adjMutex.Lock()
 	adj[v] = append(adj[v], w)
-	VMapMutex.Unlock()
 
 	return true
 }
@@ -100,6 +91,7 @@ func IsCyclic() bool {
 }
 
 func CheckSteps(steps []FixtureStep, t *testing.T) {
+	VMapMutex.Lock()
 	for _, step := range steps {
 		if len(step.ID) == 0 {
 			t.Fatal("please add ID field for all steps")
@@ -115,7 +107,7 @@ func CheckSteps(steps []FixtureStep, t *testing.T) {
 			}
 		}
 	}
-	// t.Fatal("adj Graph", adj)
+	VMapMutex.Unlock()
 	if IsCyclic() {
 		t.Fatal("cyclic dependency is available")
 	}

--- a/cmd/fixtures_test/scenarios/helicopter.json
+++ b/cmd/fixtures_test/scenarios/helicopter.json
@@ -249,8 +249,7 @@
         "paramsRef": "./check_executions/upgrader_check.json",
         "output": {
             "txResult": {
-                "status": "Success",
-                "message": "successfully completed the execution"
+                "status": "Success"
             },
             "property": {
                 "owner": "eugen",

--- a/cmd/fixtures_test/step_runner.go
+++ b/cmd/fixtures_test/step_runner.go
@@ -51,7 +51,9 @@ func RunCheckExecution(step FixtureStep, t *testing.T) {
 
 		t.MustTrue(err == nil)
 		t.MustTrue(resp.Status == step.Output.TxResult.Status)
-		t.MustTrue(resp.Message == step.Output.TxResult.Message)
+		if len(step.Output.TxResult.Message) > 0 {
+			t.MustTrue(resp.Message == step.Output.TxResult.Message)
+		}
 	}
 }
 
@@ -231,7 +233,9 @@ func RunExecuteRecipe(step FixtureStep, t *testing.T) {
 				t.Fatal("failed to parse transaction result txhash=", txhash)
 			}
 			t.MustTrue(resp.Status == step.Output.TxResult.Status)
-			t.MustTrue(resp.Message == step.Output.TxResult.Message)
+			if len(step.Output.TxResult.Message) > 0 {
+				t.MustTrue(resp.Message == step.Output.TxResult.Message)
+			}
 
 			if resp.Message == "scheduled the recipe" { // delayed execution
 				var scheduleRes handlers.ExecuteRecipeScheduleOutput


### PR DESCRIPTION
this closes #121 
- fix concurrent map read and map write for fixture test precondition checker
- Fixture test make it possible to not check success Message field when it’s ambitious (ex. Check execution)