### PR TITLE
remove TODO: comments from fulfill trade as they are not valid anymore

### DIFF
--- a/x/pylons/handlers/fulfill_trade.go
+++ b/x/pylons/handlers/fulfill_trade.go
@@ -93,10 +93,8 @@ func HandlerMsgFulfillTrade(ctx sdk.Context, keeper keep.Keeper, msg msgs.MsgFul
 		refreshedOutputItems = append(refreshedOutputItems, storedItem)
 	}
 
-	// TODO: implement rollback strategy
 	for _, item := range refreshedOutputItems {
 		item.Sender = msg.Sender
-		// TODO: implement rollback strategy here
 		err := keeper.SetItem(ctx, item)
 		if err != nil {
 			return errInternal(err2)
@@ -105,7 +103,6 @@ func HandlerMsgFulfillTrade(ctx sdk.Context, keeper keep.Keeper, msg msgs.MsgFul
 
 	for _, item := range matchedItems {
 		item.Sender = trade.Sender
-		// TODO: implement rollback strategy here
 		err := keeper.SetItem(ctx, item)
 		if err != nil {
 			return errInternal(err2)
@@ -118,7 +115,6 @@ func HandlerMsgFulfillTrade(ctx sdk.Context, keeper keep.Keeper, msg msgs.MsgFul
 	_, err = keeper.CoinKeeper.SendCoins(ctx, trade.Sender, msg.Sender, trade.CoinOutputs)
 
 	if err != nil {
-		// TODO: implement rollback strategy here
 		return errInternal(err2)
 	}
 
@@ -126,7 +122,6 @@ func HandlerMsgFulfillTrade(ctx sdk.Context, keeper keep.Keeper, msg msgs.MsgFul
 	_, err = keeper.CoinKeeper.SendCoins(ctx, msg.Sender, trade.Sender, inputCoins)
 
 	if err != nil {
-		// TODO: implement rollback strategy here
 		return errInternal(err2)
 	}
 
@@ -134,7 +129,6 @@ func HandlerMsgFulfillTrade(ctx sdk.Context, keeper keep.Keeper, msg msgs.MsgFul
 	trade.Completed = true
 	err2 = keeper.SetTrade(ctx, trade)
 	if err != nil {
-		// TODO: implement rollback strategy here
 		return errInternal(err2)
 	}
 


### PR DESCRIPTION
as mentioned here 
https://cosmos-sdk.readthedocs.io/en/stable/overview.html

> As a part of stack execution the state space provided to each middleware is isolated in the Data Store below. When executing the stack, state-recovery checkpoints can be assigned for stack execution of CheckTx or DeliverTx. This means, that all state changes will be reverted to the checkpoint state on failure when either being run as a part of CheckTx or DeliverTx. Example usage of the checkpoints is when we may want to deduct a fee even if the end business logic fails; under this situation we would add the DeliverTx checkpoint after the fee middleware but before the business logic. This diagram displays a typical process flow through an execution stack.

we don't need to implement a rollback as the data is isolated. hence removing comments