### PR TITLE
fix: exclude Amino deprecation checks in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,27 +37,12 @@ linters:
 
 issues:
   exclude-rules:
-    - text: "Use of weak random number generator"
-      linters:
-        - gosec
     - text: "comment on exported var"
       linters:
         - revive
     - text: "don't use an underscore in package name"
       linters:
         - revive
-    - text: "ST1003:"
-      linters:
-        - stylecheck
-    # FIXME: Disabled until golangci-lint updates stylecheck with this fix:
-    # https://github.com/dominikh/go-tools/issues/389
-    - text: "ST1016:"
-      linters:
-        - stylecheck
-    - path: "legacy"
-      text: "SA1019:"
-      linters:
-        - staticcheck
 
   max-issues-per-linter: 10000
   max-same-issues: 10000
@@ -65,6 +50,9 @@ issues:
 linters-settings:
   dogsled:
     max-blank-identifiers: 3
+  gosec:
+    excludes:
+      - G404
   maligned:
     # print struct with more effective memory layout or not, false by default
     suggest-new: true
@@ -73,3 +61,9 @@ linters-settings:
     allow-leading-space: true
     require-explanation: false
     require-specific: false
+
+  staticcheck:
+    go: "1.16"
+    checks: ["all", "-SA1019"]
+  stylecheck:
+    checks: ["all", "-ST1016", "ST1003"]


### PR DESCRIPTION
## Description

Modified the `.golangci.yml` config to properly exclude deprecation checks (rule SA1019). Amino is a deprecated codec in the Cosmos SDK, but is a required bit of legacy code in some parts of the codebase. Excluding this rule allows lint checks to pass.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] added `!` to the type prefix if API or client breaking change
- [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] ~~provided a link to the relevant issue or specification~~
- [ ] ~~followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)~~
- [ ] ~~included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)~~
- [ ] ~~added a changelog entry to `CHANGELOG.md`~~
- [ ] ~~included comments for [documenting Go code](https://blog.golang.org/godoc)~~
- [ ] ~~updated the relevant documentation or specification~~
- [X] reviewed "Files changed" and left comments if necessary
- [X] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] confirmed `!` in the type prefix if API or client breaking change
- [x] confirmed all author checklist items have been addressed
- [ ] ~~reviewed state machine logic~~
- [ ] ~~reviewed API design and naming~~
- [ ] ~~reviewed documentation is accurate~~
- [x] reviewed tests and test coverage
- [x] manually tested (if applicable)
