### PR TITLE
fix: improve FindValidPaymentsPermutation and add tests

### DIFF
--- a/x/pylons/keeper/msg_server_trade.go
+++ b/x/pylons/keeper/msg_server_trade.go
@@ -31,10 +31,12 @@ func (k msgServer) CreateTrade(goCtx context.Context, msg *types.MsgCreateTrade)
 		k.LockItemForTrade(ctx, item)
 		items = append(items, item)
 	}
-	for i, coinInputs := range msg.CoinInputs {
-		_, err := types.FindValidPaymentsPermutation(items, coinInputs.Coins)
-		if err != nil {
-			return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "provided coinInputs at index %d cannot satisfy itemOutputs transferFees requirements", i)
+	if len(items) != 0 {
+		for i, coinInputs := range msg.CoinInputs {
+			_, err := types.FindValidPaymentsPermutation(items, coinInputs.Coins)
+			if err != nil {
+				return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "provided coinInputs at index %d cannot satisfy itemOutputs transferFees requirements", i)
+			}
 		}
 	}
 

--- a/x/pylons/types/item.go
+++ b/x/pylons/types/item.go
@@ -313,6 +313,10 @@ func newPaymentsPermutation(permutation []int, val, maxIndex int) ([]int, int) {
 // When exploring the solution space the algorithm prioritizes the permutation where the max(permutation) is minimized.
 // For example, for a set of 3 items the permutation [1,0,2] is preferred to [3,0,0] if both are valid.
 func FindValidPaymentsPermutation(items []Item, balance sdk.Coins) ([]int, error) {
+	if len(items) == 0 {
+		return nil, errors.New("invalid set of Items provided")
+	}
+
 	if balance.Empty() || !balance.IsValid() {
 		return nil, errors.New("invalid balance provided")
 	}

--- a/x/pylons/types/item_test.go
+++ b/x/pylons/types/item_test.go
@@ -100,7 +100,7 @@ func TestFindValidPaymentsPermutation(t *testing.T) {
 			desc: "Invalid1",
 			// {"coin0", 10}
 			balance: sdk.Coins{sdk.NewCoin("coin0", sdk.NewInt(10))},
-			err:     errors.New(fmt.Sprintf("insufficient balance to transfer item wiht ID %v in cookbook with ID %v", items[1].ID, items[1].CookbookID)),
+			err:     fmt.Errorf("insufficient balance to transfer item with ID %v in cookbook with ID %v", items[1].ID, items[1].CookbookID),
 		},
 		{
 			desc: "Invalid2",


### PR DESCRIPTION
## Description

Current implementation of `FindValidPaymentsPermutation` does not work properly (in particular, it does not inspect the whole search space) nor has tests. With this PR the functionality now works as intended (added a few comments to clarify), plus i added a few unit-tests.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
