### PR TITLE
test: atomgachi test

### DIFF
--- a/x/pylons/client/cli/atomgachi_test.go
+++ b/x/pylons/client/cli/atomgachi_test.go
@@ -1,0 +1,177 @@
+package cli_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Pylons-tech/pylons/testutil/network"
+	"github.com/Pylons-tech/pylons/x/pylons/client/cli"
+	"github.com/Pylons-tech/pylons/x/pylons/types"
+)
+
+const (
+	cookbookIDAtomgachi = "atomgachiV2"
+)
+
+type atomgachiBasicSim struct {
+	net                  *network.Network
+	ctx                  client.Context
+	basicTradePercentage sdk.Dec
+	err                  error
+	common               []string
+	execCount            int
+	itemCount            int
+	mintRecipeID         string
+	mintRecipeID2        string
+}
+
+func TestAtomgachiBasic(t *testing.T) {
+	net := network.New(t)
+	val := net.Validators[0]
+	ctx := val.ClientCtx
+	var err error
+
+	simInfo := &atomgachiBasicSim{
+		net:                  net,
+		ctx:                  ctx,
+		basicTradePercentage: sdk.Dec{},
+		err:                  nil,
+		common:               nil,
+	}
+
+	simInfo.basicTradePercentage, err = sdk.NewDecFromStr("0.10")
+	require.NoError(t, err)
+
+	simInfo.common = []string{
+		fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
+		fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
+		fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
+		fmt.Sprintf("--%s=%s", flags.FlagFees, sdk.NewCoins(sdk.NewCoin(net.Config.BondDenom, sdk.NewInt(10))).String()),
+	}
+
+	createAtomgachiCookbook(t, simInfo)
+	createMintRecipe(t, simInfo)
+	mint(t, simInfo)
+}
+
+func createAtomgachiCookbook(t *testing.T, simInfo *atomgachiBasicSim) {
+	cbFields := []string{
+		"Atomgachi Test Cookbook",
+		"Cookbook for testing demo atomgachi transactions",
+		"Pylons Inc",
+		"v0.0.1",
+		"alex@shmeeload.xyz",
+		"{\"denom\": \"pylons\", \"amount\": \"12\"}",
+		"true",
+	}
+
+	// create Atomgachi cookbook
+	args := []string{cookbookIDAtomgachi}
+	args = append(args, cbFields...)
+	args = append(args, simInfo.common...)
+	_, err := clitestutil.ExecTestCLICmd(simInfo.ctx, cli.CmdCreateCookbook(), args)
+	require.NoError(t, err)
+}
+
+func createMintRecipe(t *testing.T, simInfo *atomgachiBasicSim) {
+	coinInputs, err := json.Marshal([]types.CoinInput{})
+	require.NoError(t, err)
+
+	entries, err := json.Marshal(types.EntriesList{
+		CoinOutputs: nil,
+		ItemOutputs: []types.ItemOutput{{
+			ID: "atomgachiTestCreate",
+			Strings: []types.StringParam{
+				{
+					Key:     "name",
+					Value:   "testObject",
+					Program: "",
+				}},
+			MutableStrings:  nil,
+			TransferFee:     nil,
+			TradePercentage: simInfo.basicTradePercentage,
+			Tradeable:       true,
+		}},
+		ItemModifyOutputs: nil,
+	})
+	require.NoError(t, err)
+
+	itemOutputs, err := json.Marshal([]types.WeightedOutputs{
+		{
+			EntryIDs: []string{"atomgachiTestCreate"},
+			Weight:   1,
+		},
+	})
+
+	// Get Character Recipe
+	simInfo.mintRecipeID = "atomgachiTestCreate"
+	mintNFTRecipe := []string{
+		"Atom with it's Number here",
+		"mijollae is testing the demo process",
+		"v0.0.1",
+		string(coinInputs),
+		"[]",
+		string(entries),
+		string(itemOutputs),
+		"0",
+		"true",
+		"extraInfo",
+	}
+
+	// create recipe
+	args := []string{cookbookIDAtomgachi, simInfo.mintRecipeID}
+	args = append(args, mintNFTRecipe...)
+	fmt.Println(args)
+	args = append(args, simInfo.common...)
+	_, err = clitestutil.ExecTestCLICmd(simInfo.ctx, cli.CmdCreateRecipe(), args)
+	require.NoError(t, err)
+}
+
+func mint(t *testing.T, simInfo *atomgachiBasicSim) {
+	// execute recipe to mint
+	args := []string{cookbookIDAtomgachi, simInfo.mintRecipeID, "0", "[]", "[]"} // empty list for item-ids since there is no item input
+	args = append(args, simInfo.common...)
+	out, err := clitestutil.ExecTestCLICmd(simInfo.ctx, cli.CmdExecuteRecipe(), args)
+	require.NoError(t, err)
+	var resp sdk.TxResponse
+	require.NoError(t, simInfo.ctx.JSONCodec.UnmarshalJSON(out.Bytes(), &resp))
+	require.Equal(t, uint32(0), resp.Code)
+
+	// simulate waiting for later block heights
+	height, err := simInfo.net.LatestHeight()
+	targetHeight := height + 1
+	// build execID from the execution height
+	execID := strconv.Itoa(int(height+0)) + "-" + strconv.Itoa(simInfo.execCount)
+	simInfo.execCount++
+	require.NoError(t, err)
+	_, err = simInfo.net.WaitForHeightWithTimeout(targetHeight, 60*time.Second)
+	require.NoError(t, err)
+
+	// check the execution
+	args = []string{execID}
+	out, err = clitestutil.ExecTestCLICmd(simInfo.ctx, cli.CmdShowExecution(), args)
+	require.NoError(t, err)
+	var execResp types.QueryGetExecutionResponse
+	require.NoError(t, simInfo.ctx.JSONCodec.UnmarshalJSON(out.Bytes(), &execResp))
+	// verify completed
+	require.Equal(t, true, execResp.Completed)
+
+	// check the item, itemID is i
+	nftID := types.EncodeItemID(uint64(simInfo.itemCount))
+	simInfo.itemCount++
+	args = []string{cookbookIDAtomgachi, nftID}
+	out, err = clitestutil.ExecTestCLICmd(simInfo.ctx, cli.CmdShowItem(), args)
+	require.NoError(t, err)
+	var itemResp types.QueryGetItemResponse
+	require.NoError(t, simInfo.ctx.JSONCodec.UnmarshalJSON(out.Bytes(), &itemResp))
+	require.Equal(t, cookbookIDAtomgachi, itemResp.Item.CookbookID)
+}

--- a/x/pylons/client/cli/easel_test.go
+++ b/x/pylons/client/cli/easel_test.go
@@ -78,7 +78,7 @@ func createEaselCookbook(t *testing.T, simInfo *easelBasicSim) {
 		"true",
 	}
 
-	// create LOUD cookbook
+	// create Easel cookbook
 	args := []string{cookbookIDEasel}
 	args = append(args, cbFields...)
 	args = append(args, simInfo.common...)

--- a/x/pylons/types/redeem_info.pb.go
+++ b/x/pylons/types/redeem_info.pb.go
@@ -5,13 +5,12 @@ package types
 
 import (
 	fmt "fmt"
-	io "io"
-	math "math"
-	math_bits "math/bits"
-
 	github_com_cosmos_cosmos_sdk_types "github.com/cosmos/cosmos-sdk/types"
 	_ "github.com/gogo/protobuf/gogoproto"
 	proto "github.com/gogo/protobuf/proto"
+	io "io"
+	math "math"
+	math_bits "math/bits"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Test to replicate atomgachi flow. No core files modified.

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] added `!` to the type prefix if API or client breaking change
- [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X] provided a link to the relevant issue or specification
- [X] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [X] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [X] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [X] updated the relevant documentation or specification
- [X] reviewed "Files changed" and left comments if necessary
- [X] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)