### PR TITLE
feat: telemetry rewrite

### DIFF
--- a/x/pylons/keeper/complete_pending_execution.go
+++ b/x/pylons/keeper/complete_pending_execution.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/rogpeppe/go-internal/semver"
 
-	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"github.com/Pylons-tech/pylons/x/pylons/types"
 )
@@ -220,6 +220,9 @@ coinLoop:
 		MintItems:     mintItems,
 		ModifyItems:   modifyItems,
 	}
+
+	telemetry.IncrCounter(1, "execution", "cookbookID", pendingExecution.CookbookID, "recipeID", pendingExecution.RecipeID)
+	telemetry.IncrCounter(1, "execution", "total")
 
 	return pendingExecution, event, true, nil
 }

--- a/x/pylons/keeper/msg_server_account.go
+++ b/x/pylons/keeper/msg_server_account.go
@@ -40,6 +40,8 @@ func (k msgServer) CreateAccount(goCtx context.Context, msg *types.MsgCreateAcco
 		Username: msg.Username,
 	})
 
+	telemetry.IncrCounter(1, "account", "create")
+
 	return &types.MsgCreateAccountResponse{}, err
 }
 
@@ -76,6 +78,8 @@ func (k msgServer) UpdateAccount(goCtx context.Context, msg *types.MsgUpdateAcco
 		Address:  msg.Creator,
 		Username: msg.Username,
 	})
+
+	telemetry.IncrCounter(1, "account", "update")
 
 	return &types.MsgUpdateAccountResponse{}, err
 }

--- a/x/pylons/keeper/msg_server_cookbook.go
+++ b/x/pylons/keeper/msg_server_cookbook.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
@@ -48,6 +49,8 @@ func (k msgServer) CreateCookbook(goCtx context.Context, msg *types.MsgCreateCoo
 		Creator: cookbook.Creator,
 		ID:      cookbook.ID,
 	})
+
+	telemetry.IncrCounter(1, "cookbook", "create")
 
 	return &types.MsgCreateCookbookResponse{}, err
 }
@@ -98,6 +101,8 @@ func (k msgServer) UpdateCookbook(goCtx context.Context, msg *types.MsgUpdateCoo
 	err = ctx.EventManager().EmitTypedEvent(&types.EventUpdateCookbook{
 		OriginalCookbook: origCookbook,
 	})
+
+	telemetry.IncrCounter(1, "cookbook", "update")
 
 	return &types.MsgUpdateCookbookResponse{}, err
 }

--- a/x/pylons/keeper/msg_server_fulfill_trade.go
+++ b/x/pylons/keeper/msg_server_fulfill_trade.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strconv"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -253,6 +254,8 @@ func (k msgServer) FulfillTrade(goCtx context.Context, msg *types.MsgFulfillTrad
 		CoinOutputs:  coinOutputs,
 		PaymentInfos: msg.PaymentInfos,
 	})
+
+	telemetry.IncrCounter(1, "trade", "fulfill")
 
 	return &types.MsgFulfillTradeResponse{}, err
 }

--- a/x/pylons/keeper/msg_server_recipe.go
+++ b/x/pylons/keeper/msg_server_recipe.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rogpeppe/go-internal/semver"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
@@ -64,6 +65,8 @@ func (k msgServer) CreateRecipe(goCtx context.Context, msg *types.MsgCreateRecip
 		CookbookID: recipe.CookbookID,
 		ID:         recipe.ID,
 	})
+
+	telemetry.IncrCounter(1, "recipe", "create")
 
 	return &types.MsgCreateRecipeResponse{}, err
 }
@@ -126,6 +129,8 @@ func (k msgServer) UpdateRecipe(goCtx context.Context, msg *types.MsgUpdateRecip
 	err = ctx.EventManager().EmitTypedEvent(&types.EventUpdateRecipe{
 		OriginalRecipe: origRecipe,
 	})
+
+	telemetry.IncrCounter(1, "recipe", "update")
 
 	return &types.MsgUpdateRecipeResponse{}, err
 }

--- a/x/pylons/keeper/msg_server_send_items.go
+++ b/x/pylons/keeper/msg_server_send_items.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -98,6 +99,8 @@ func (k msgServer) SendItems(goCtx context.Context, msg *types.MsgSendItems) (*t
 		Receiver: msg.Receiver,
 		Items:    msg.Items,
 	})
+
+	telemetry.IncrCounter(float32(len(msg.Items)), "send_items", "send")
 
 	return &types.MsgSendItemsResponse{}, err
 }

--- a/x/pylons/keeper/msg_server_trade.go
+++ b/x/pylons/keeper/msg_server_trade.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
@@ -86,6 +87,8 @@ func (k msgServer) CreateTrade(goCtx context.Context, msg *types.MsgCreateTrade)
 		ID:      id,
 	})
 
+	telemetry.IncrCounter(1, "trade", "create")
+
 	return &types.MsgCreateTradeResponse{
 		ID: id,
 	}, err
@@ -123,6 +126,8 @@ func (k msgServer) CancelTrade(goCtx context.Context, msg *types.MsgCancelTrade)
 		Creator: msg.Creator,
 		ID:      msg.ID,
 	})
+
+	telemetry.IncrCounter(1, "trade", "cancel")
 
 	return &types.MsgCancelTradeResponse{}, err
 }

--- a/x/pylons/module.go
+++ b/x/pylons/module.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/cosmos/cosmos-sdk/telemetry"
-
 	"github.com/Pylons-tech/pylons/x/pylons/simulation"
 
 	"github.com/gorilla/mux"
@@ -176,12 +174,6 @@ func (am AppModule) BeginBlock(_ sdk.Context, _ abci.RequestBeginBlock) {}
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
 	blockHeight := ctx.BlockHeight()
 	pendingExecs := am.keeper.GetAllPendingExecutionAtBlockHeight(ctx, blockHeight)
-
-	defer func() {
-		for _, exec := range pendingExecs {
-			telemetry.IncrCounter(1, "execution", "cookbookID", exec.CookbookID, "recipeID", exec.RecipeID)
-		}
-	}()
 
 	for _, pendingExec := range pendingExecs {
 		finalizedExec, event, coinsUnlocked, err := am.keeper.CompletePendingExecution(ctx, pendingExec)


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Add new telemetry hooks.


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] added `!` to the type prefix if API or client breaking change
- [X] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X] provided a link to the relevant issue or specification
- [X] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [X] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [X] added a changelog entry to `CHANGELOG.md`
- [X] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [X] updated the relevant documentation or specification
- [X] reviewed "Files changed" and left comments if necessary
- [X] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)