### PR TITLE
fix/ibc owner transfer coins

### DIFF
--- a/cmd/pylonsd/main.go
+++ b/cmd/pylonsd/main.go
@@ -23,7 +23,7 @@ func main() {
 		// this line is used by starport scaffolding # root/arguments
 	)
 	rootCmd.Short = "Stargate Pylons App"
-	rootCmd.AddCommand()
+	rootCmd.AddCommand(Completion())
 	removeLineBreaksInCobraArgs(rootCmd)
 	if err := svrcmd.Execute(rootCmd, app.DefaultNodeHome); err != nil {
 		os.Exit(1)

--- a/cmd/pylonsd/main.go
+++ b/cmd/pylonsd/main.go
@@ -23,7 +23,7 @@ func main() {
 		// this line is used by starport scaffolding # root/arguments
 	)
 	rootCmd.Short = "Stargate Pylons App"
-	rootCmd.AddCommand(Completion())
+	rootCmd.AddCommand()
 	removeLineBreaksInCobraArgs(rootCmd)
 	if err := svrcmd.Execute(rootCmd, app.DefaultNodeHome); err != nil {
 		os.Exit(1)

--- a/x/pylons/keeper/complete_pending_execution.go
+++ b/x/pylons/keeper/complete_pending_execution.go
@@ -135,7 +135,12 @@ func (k Keeper) CompletePendingExecution(ctx sdk.Context, pendingExecution types
 	transferCoins := sdk.NewCoins()
 	feeCoins := sdk.NewCoins()
 
+coinLoop:
 	for _, coin := range pendingExecution.CoinInputs {
+		if types.IsCookbookDenom(coin.Denom) {
+			burnCoins = burnCoins.Add(coin)
+			continue coinLoop
+		}
 
 		payCoins = payCoins.Add(coin)
 		feeAmt := coin.Amount.ToDec().Mul(k.RecipeFeePercentage(ctx)).RoundInt()

--- a/x/pylons/keeper/complete_pending_execution.go
+++ b/x/pylons/keeper/complete_pending_execution.go
@@ -134,12 +134,9 @@ func (k Keeper) CompletePendingExecution(ctx sdk.Context, pendingExecution types
 	payCoins := sdk.NewCoins()
 	transferCoins := sdk.NewCoins()
 	feeCoins := sdk.NewCoins()
-coinLoop:
+
 	for _, coin := range pendingExecution.CoinInputs {
-		if types.IsCookbookDenom(coin.Denom) {
-			burnCoins = burnCoins.Add(coin)
-			continue coinLoop
-		}
+
 		payCoins = payCoins.Add(coin)
 		feeAmt := coin.Amount.ToDec().Mul(k.RecipeFeePercentage(ctx)).RoundInt()
 		coin.Amount = coin.Amount.Sub(feeAmt)

--- a/x/pylons/types/coins.go
+++ b/x/pylons/types/coins.go
@@ -23,6 +23,12 @@ const (
 
 	denomDivider = "/"
 	ibcPrefix    = "ibc"
+
+	// minimum splits for cookbook
+	minCookBookDenomSplits = 2
+
+	// index for cook book id after splits
+	cookbookIdIndex = 0
 )
 
 // CookbookDenom converts a cookbookID, denom pair into a valid cookbookDenom string
@@ -38,7 +44,7 @@ func CookbookDenom(cookbookID, denom string) (string, error) {
 // If denom is IBC denom we will not consider for CookBookDenom
 func IsCookbookDenom(denom string) bool {
 	split := strings.Split(denom, denomDivider)
-	if len(split) != 2 {
+	if len(split) != minCookBookDenomSplits {
 		return false
 	}
 
@@ -47,7 +53,7 @@ func IsCookbookDenom(denom string) bool {
 		return false
 	}
 	// validate cookbook ID
-	err := ValidateID(split[0])
+	err := ValidateID(split[cookbookIdIndex])
 	if err != nil {
 		return false
 	}

--- a/x/pylons/types/coins.go
+++ b/x/pylons/types/coins.go
@@ -28,7 +28,7 @@ const (
 	minCookBookDenomSplits = 2
 
 	// index for cook book id after splits
-	cookbookIdIndex = 0
+	cookbookIDIndex = 0
 )
 
 // CookbookDenom converts a cookbookID, denom pair into a valid cookbookDenom string
@@ -53,7 +53,7 @@ func IsCookbookDenom(denom string) bool {
 		return false
 	}
 	// validate cookbook ID
-	err := ValidateID(split[cookbookIdIndex])
+	err := ValidateID(split[cookbookIDIndex])
 	if err != nil {
 		return false
 	}

--- a/x/pylons/types/coins.go
+++ b/x/pylons/types/coins.go
@@ -35,12 +35,17 @@ func CookbookDenom(cookbookID, denom string) (string, error) {
 }
 
 // IsCookbookDenom checks if an inputted denom is a valid cookbookDenom
+// If denom is IBC denom we will not consider for CookBookDenom
 func IsCookbookDenom(denom string) bool {
 	split := strings.Split(denom, denomDivider)
 	if len(split) != 2 {
 		return false
 	}
 
+	// check if it is IBC denom
+	if IsIBCDenomRepresentation(denom) {
+		return false
+	}
 	// validate cookbook ID
 	err := ValidateID(split[0])
 	if err != nil {

--- a/x/pylons/types/coins_test.go
+++ b/x/pylons/types/coins_test.go
@@ -20,6 +20,9 @@ func TestCookbookDenom(t *testing.T) {
 	invalid1 := "1234/567"
 	invalid2 := "pylons"
 	invalid3, _ := CookbookDenom("12341234", "pylons")
+	invalid4 := "ibc/529ba5e3e86ba7796d7caab4fc02728935fbc75c0f7b25a9e611c49dd7d68a35"
+	invalid5, _ := CookbookDenom("a12341234", "ibc/529ba5e3e86ba7796d7caab4fc02728935fbc75c0f7b25a9e611c49dd7d68a35")
+	invalid6, _ := CookbookDenom("ibc", "529ba5e3e86ba7796d7caab4fc02728935fbc75c0f7b25a9e611c49dd7d68a35")
 
 	for _, tc := range []struct {
 		desc  string
@@ -31,6 +34,9 @@ func TestCookbookDenom(t *testing.T) {
 		{desc: "invalid1", denom: invalid1, is: false},
 		{desc: "invalid2", denom: invalid2, is: false},
 		{desc: "invalid3", denom: invalid3, is: false},
+		{desc: "invalid4", denom: invalid4, is: false},
+		{desc: "invalid5", denom: invalid5, is: false},
+		{desc: "invalid6", denom: invalid6, is: false},
 	} {
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION

## Description

when a user buy NFT, token should be transfer to user, in this PR this issue of token transfer to owner was resolved for IBC tokens

Closes: #PS-63

complete_pending_execution was updated

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [x] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)