### PR TITLE
update testing msg_server_cookbook_test with table-driven test

### DIFF
--- a/x/pylons/keeper/msg_server_cookbook_test.go
+++ b/x/pylons/keeper/msg_server_cookbook_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func (suite *IntegrationTestSuite) TestCookbookMsgServerCreate() {
+
 	k := suite.k
 	ctx := suite.ctx
 	require := suite.Require()
@@ -20,28 +21,75 @@ func (suite *IntegrationTestSuite) TestCookbookMsgServerCreate() {
 	wctx := sdk.WrapSDKContext(ctx)
 	creator := "TestCreator"
 	desc := "TestDescriptionTestDescription"
-	for i := 0; i < 5; i++ {
-		idx := fmt.Sprintf("%d", i)
-		expected := &types.MsgCreateCookbook{
-			Creator:      creator,
-			Id:           idx,
-			Name:         desc,
-			Description:  desc,
-			Developer:    desc,
-			Version:      "v0.0.1",
-			SupportEmail: "test@email.com",
-			Enabled:      false,
-		}
-		_, err := srv.CreateCookbook(wctx, expected)
-		require.NoError(err)
-	}
+	index := "testing"
 
-	for i := 0; i < 5; i++ {
-		idx := fmt.Sprintf("%d", i)
-		rst, found := k.GetCookbook(ctx, idx)
-		require.True(found)
-		require.Equal(creator, rst.Creator)
-		require.Equal(desc, rst.Description)
+	anchorMsg := &types.MsgCreateCookbook{
+		Creator:      creator,
+		Id:           index,
+		Name:         desc,
+		Description:  desc,
+		Developer:    desc,
+		Version:      "v0.0.1",
+		SupportEmail: "test@email.com",
+		Enabled:      false,
+	}
+	for _, tc := range []struct {
+		desc  string
+		msgs  []types.MsgCreateCookbook
+		valid bool
+	}{
+		{
+			desc: "Invalid request: ID already set",
+			msgs: []types.MsgCreateCookbook{
+				*anchorMsg,
+				{
+					Creator:      creator,
+					Id:           index,
+					Name:         desc,
+					Description:  desc,
+					Developer:    desc,
+					Version:      "v0.0.1",
+					SupportEmail: "test@email.com",
+					Enabled:      false,
+				},
+			},
+			valid: false,
+		},
+		{
+			desc: "Valid",
+			msgs: []types.MsgCreateCookbook{
+				*anchorMsg,
+				{Creator: creator,
+					Id:           "validcase",
+					Name:         desc,
+					Description:  desc,
+					Developer:    desc,
+					Version:      "v0.0.1",
+					SupportEmail: "test@email.com",
+					Enabled:      false,
+				},
+			},
+			valid: true,
+		},
+	} {
+		suite.Run(fmt.Sprintf("Case %s", tc.desc), func() {
+			var err error
+			for _, msg := range tc.msgs {
+				_, err = srv.CreateCookbook(wctx, &msg)
+			}
+			if tc.valid {
+				suite.Require().NoError(err)
+				for _, msg := range tc.msgs {
+					rst, found := k.GetCookbook(ctx, msg.Id)
+					require.True(found)
+					require.Equal(creator, rst.Creator)
+					require.Equal(desc, rst.Description)
+				}
+
+			} else {
+				suite.Require().Error(err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->
## What is the purpose of the change
   - Add table-driven test for function `TestCookbookMsgServerCreate` in `msg_server_complete_execution_early_test.go`
## Brief Changelog
   - Add more test cases and add table-driven tests for test cases
## Testing and Verifying
   - This change is a trivial rework/code cleanup without any test coverage. 
## Documentation and Release Note
   - Does this pull request introduces a new feature or user-facing behaviour changes? no 
   - How is the feature or change documented? not applicable
## Notional-labs
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---