### PR TITLE
update testing msg_server_execute_recipe_test with table-driven test …

### DIFF
--- a/x/pylons/keeper/msg_server_execute_recipe.go
+++ b/x/pylons/keeper/msg_server_execute_recipe.go
@@ -66,15 +66,14 @@ func (k Keeper) MatchItemInputsForExecution(ctx sdk.Context, creatorAddr string,
 func (k msgServer) ExecuteRecipe(goCtx context.Context, msg *types.MsgExecuteRecipe) (*types.MsgExecuteRecipeResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
+	cookbook, found := k.GetCookbook(ctx, msg.CookbookId)
+	if !found {
+		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "main cookbook not found")
+	}
+
 	recipe, found := k.GetRecipe(ctx, msg.CookbookId, msg.RecipeId)
 	if !found {
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "requested recipe not found")
-	}
-
-	cookbook, found := k.GetCookbook(ctx, msg.CookbookId)
-
-	if !found {
-		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidRequest, "main cookbook not found")
 	}
 
 	// check if the recipe creator and the recipe executor are same

--- a/x/pylons/keeper/msg_server_execute_recipe_test.go
+++ b/x/pylons/keeper/msg_server_execute_recipe_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -8,9 +9,10 @@ import (
 
 	"github.com/Pylons-tech/pylons/x/pylons/keeper"
 	"github.com/Pylons-tech/pylons/x/pylons/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 )
 
-func (suite *IntegrationTestSuite) TestExecuteRecipe() {
+func (suite *IntegrationTestSuite) TestExecuteRecipe2() {
 	k := suite.k
 	ctx := suite.ctx
 	require := suite.Require()
@@ -18,7 +20,8 @@ func (suite *IntegrationTestSuite) TestExecuteRecipe() {
 	srv := keeper.NewMsgServerImpl(k)
 	wctx := sdk.WrapSDKContext(ctx)
 
-	creator := "A"
+	privKey := ed25519.GenPrivKey()
+	creator := "testPylon"
 	types.UpdateAppCheckFlagTest(types.FlagTrue)
 
 	_, err := srv.CreateAccount(wctx, &types.MsgCreateAccount{
@@ -26,57 +29,389 @@ func (suite *IntegrationTestSuite) TestExecuteRecipe() {
 		Username: "test",
 	})
 	require.NoError(err)
-	for i := 0; i < 5; i++ {
-		idx := fmt.Sprintf("%d", i)
-		cookbook := &types.MsgCreateCookbook{
-			Creator:      creator,
-			Id:           idx,
-			Name:         "testCookbookName",
-			Description:  "descdescdescdescdescdesc",
-			Developer:    "",
-			Version:      "v0.0.1",
-			SupportEmail: "test@email.com",
-			Enabled:      true,
-		}
-		_, err := srv.CreateCookbook(wctx, cookbook)
-		require.NoError(err)
-		recipe := &types.MsgCreateRecipe{
-			Creator:       creator,
-			CookbookId:    idx,
-			Id:            idx,
-			Name:          "testRecipeName",
-			Description:   "decdescdescdescdescdescdescdesc",
-			Version:       "v0.0.1",
-			CoinInputs:    nil,
-			ItemInputs:    nil,
-			Entries:       types.EntriesList{},
-			Outputs:       nil,
-			BlockInterval: 0,
-			CostPerBlock:  sdk.Coin{Denom: "test", Amount: sdk.ZeroInt()},
-			Enabled:       true,
-			ExtraInfo:     "",
-		}
-		_, err = srv.CreateRecipe(wctx, recipe)
-		require.NoError(err)
-		rst, found := k.GetRecipe(ctx, recipe.CookbookId, recipe.Id)
-		require.True(found)
-		require.Equal(recipe.Id, rst.Id)
 
-		execution := &types.MsgExecuteRecipe{
-			Creator:         types.TestCreator,
-			CookbookId:      idx,
-			RecipeId:        idx,
-			CoinInputsIndex: 0,
-			ItemIds:         nil,
-		}
-		_, err = srv.ExecuteRecipe(wctx, execution)
-		require.NoError(err)
-
-		completed, pending := k.GetAllExecutionByRecipe(ctx, recipe.CookbookId, recipe.Id)
-		require.Equal(0, len(completed))
-		require.Equal(1, len(pending))
+	cookbook := &types.MsgCreateCookbook{
+		Creator:      creator,
+		Id:           "",
+		Name:         "testCookbookName",
+		Description:  "descdescdescdescdescdesc",
+		Developer:    "",
+		Version:      "v0.0.1",
+		SupportEmail: "test@email.com",
+		Enabled:      true,
 	}
-	types.UpdateAppCheckFlagTest(types.FlagFalse)
+
+	recipe := &types.MsgCreateRecipe{
+		Creator:       creator,
+		CookbookId:    "",
+		Id:            "",
+		Name:          "testRecipeName",
+		Description:   "decdescdescdescdescdescdescdesc",
+		Version:       "v0.0.1",
+		CoinInputs:    nil,
+		ItemInputs:    nil,
+		Entries:       types.EntriesList{},
+		Outputs:       nil,
+		BlockInterval: 0,
+		CostPerBlock:  sdk.Coin{Denom: "test", Amount: sdk.ZeroInt()},
+		Enabled:       true,
+		ExtraInfo:     "",
+	}
+	for index, tc := range []struct {
+		decs                  string
+		cookbook              types.MsgCreateCookbook
+		unEnabledCookbook     bool
+		changeIdCookbook      bool
+		recipe                types.MsgCreateRecipe
+		changeIdRecipe        bool
+		updateCoinInputs      bool
+		updateEntriesRecipe   bool
+		execution             types.MsgExecuteRecipe
+		changeExcutionCreator bool
+		valid                 bool
+	}{
+		{
+			decs:                "Main cookbook not found",
+			cookbook:            *cookbook,
+			unEnabledCookbook:   false,
+			changeIdCookbook:    true,
+			recipe:              *recipe,
+			changeIdRecipe:      false,
+			updateCoinInputs:    false,
+			updateEntriesRecipe: false,
+			execution: types.MsgExecuteRecipe{
+				Creator:         types.TestCreator,
+				CookbookId:      "",
+				RecipeId:        "",
+				CoinInputsIndex: 0,
+				ItemIds:         nil,
+			},
+			changeExcutionCreator: false,
+			valid:                 false,
+		},
+		{
+			decs:                "Requested recipe not found",
+			cookbook:            *cookbook,
+			unEnabledCookbook:   false,
+			changeIdCookbook:    false,
+			recipe:              *recipe,
+			changeIdRecipe:      true,
+			updateCoinInputs:    false,
+			updateEntriesRecipe: false,
+			execution: types.MsgExecuteRecipe{
+				Creator:         types.TestCreator,
+				CookbookId:      "",
+				RecipeId:        "",
+				CoinInputsIndex: 0,
+				ItemIds:         nil,
+			},
+			changeExcutionCreator: false,
+			valid:                 false,
+		},
+		{
+			decs:                "Recipe Executor Cannot Be Same As Creator",
+			cookbook:            *cookbook,
+			unEnabledCookbook:   false,
+			changeIdCookbook:    false,
+			recipe:              *recipe,
+			changeIdRecipe:      false,
+			updateCoinInputs:    false,
+			updateEntriesRecipe: false,
+			execution: types.MsgExecuteRecipe{
+				Creator:         types.TestCreator,
+				CookbookId:      "",
+				RecipeId:        "",
+				CoinInputsIndex: 0,
+				ItemIds:         nil,
+			},
+			changeExcutionCreator: true,
+			valid:                 false,
+		},
+		{
+			decs:                "Recipe or its parent cookbook are disabled",
+			cookbook:            *cookbook,
+			unEnabledCookbook:   true,
+			changeIdCookbook:    false,
+			recipe:              *recipe,
+			changeIdRecipe:      false,
+			updateCoinInputs:    false,
+			updateEntriesRecipe: false,
+			execution: types.MsgExecuteRecipe{
+				Creator:         types.TestCreator,
+				CookbookId:      "",
+				RecipeId:        "",
+				CoinInputsIndex: 0,
+				ItemIds:         nil,
+			},
+			changeExcutionCreator: false,
+			valid:                 false,
+		},
+		{
+			decs:                "Don't match ItemInput for Execution",
+			cookbook:            *cookbook,
+			unEnabledCookbook:   false,
+			changeIdCookbook:    false,
+			recipe:              *recipe,
+			changeIdRecipe:      false,
+			updateCoinInputs:    false,
+			updateEntriesRecipe: false,
+			execution: types.MsgExecuteRecipe{
+				Creator:         types.TestCreator,
+				CookbookId:      "",
+				RecipeId:        "",
+				CoinInputsIndex: 0,
+				ItemIds:         []string{"1"},
+			},
+			changeExcutionCreator: false,
+			valid:                 false,
+		},
+		{
+			decs:                "Invalid coinInputs index",
+			cookbook:            *cookbook,
+			unEnabledCookbook:   false,
+			changeIdCookbook:    false,
+			recipe:              *recipe,
+			changeIdRecipe:      false,
+			updateCoinInputs:    true,
+			updateEntriesRecipe: false,
+			execution: types.MsgExecuteRecipe{
+				Creator:         types.TestCreator,
+				CookbookId:      "",
+				RecipeId:        "",
+				CoinInputsIndex: 2,
+				ItemIds:         nil,
+			},
+			changeExcutionCreator: false,
+			valid:                 false,
+		},
+		{
+			decs:                "Invalid PaymentInfo",
+			cookbook:            *cookbook,
+			unEnabledCookbook:   false,
+			changeIdCookbook:    false,
+			recipe:              *recipe,
+			changeIdRecipe:      false,
+			updateCoinInputs:    false,
+			updateEntriesRecipe: false,
+			execution: types.MsgExecuteRecipe{
+				Creator:         types.TestCreator,
+				CookbookId:      "",
+				RecipeId:        "",
+				CoinInputsIndex: 0,
+				ItemIds:         nil,
+				PaymentInfos: []types.PaymentInfo{
+					{
+						PurchaseId:    "1",
+						ProcessorName: "test",
+						PayerAddr:     "pylon0123",
+						Amount:        sdk.OneInt(),
+						ProductId:     "1",
+						Signature:     "test",
+					},
+				},
+			},
+			changeExcutionCreator: false,
+			valid:                 false,
+		},
+		{
+			decs:                "Amount minted reached maximum limit",
+			cookbook:            *cookbook,
+			unEnabledCookbook:   false,
+			changeIdCookbook:    false,
+			recipe:              *recipe,
+			changeIdRecipe:      false,
+			updateCoinInputs:    false,
+			updateEntriesRecipe: true,
+			execution: types.MsgExecuteRecipe{
+				Creator:         types.TestCreator,
+				CookbookId:      "",
+				RecipeId:        "",
+				CoinInputsIndex: 0,
+				ItemIds:         nil,
+			},
+			changeExcutionCreator: false,
+			valid:                 false,
+		},
+		{
+			decs:                "Process PaymentInfo error",
+			cookbook:            *cookbook,
+			unEnabledCookbook:   false,
+			changeIdCookbook:    false,
+			recipe:              *recipe,
+			changeIdRecipe:      false,
+			updateCoinInputs:    false,
+			updateEntriesRecipe: true,
+			execution: types.MsgExecuteRecipe{
+				Creator:         types.TestCreator,
+				CookbookId:      "",
+				RecipeId:        "",
+				CoinInputsIndex: 0,
+				ItemIds:         nil,
+				PaymentInfos: []types.PaymentInfo{{
+					PurchaseId:    "test",
+					ProcessorName: "TestPayment",
+					PayerAddr:     types.GenTestBech32FromString(types.TestCreator),
+					Amount:        sdk.NewInt(2),
+					ProductId:     "testProductId",
+					Signature:     genTestPaymentInfoSignature("testPurchaseId", types.GenTestBech32FromString(types.TestCreator), "testProductId", sdk.NewInt(2), privKey),
+				}},
+			},
+			changeExcutionCreator: false,
+			valid:                 false,
+		},
+		{
+			decs:                "Error lock coins for execution",
+			cookbook:            *cookbook,
+			unEnabledCookbook:   false,
+			changeIdCookbook:    false,
+			recipe:              *recipe,
+			changeIdRecipe:      false,
+			updateCoinInputs:    true,
+			updateEntriesRecipe: false,
+			execution: types.MsgExecuteRecipe{
+				Creator:         types.TestCreator,
+				CookbookId:      "",
+				RecipeId:        "",
+				CoinInputsIndex: 0,
+				ItemIds:         nil,
+			},
+			changeExcutionCreator: false,
+			valid:                 false,
+		},
+		{
+			decs:                "User account username not found",
+			cookbook:            *cookbook,
+			unEnabledCookbook:   false,
+			changeIdCookbook:    false,
+			recipe:              *recipe,
+			changeIdRecipe:      false,
+			updateCoinInputs:    false,
+			updateEntriesRecipe: false,
+			execution: types.MsgExecuteRecipe{
+				Creator:         "invalid",
+				CookbookId:      "",
+				RecipeId:        "",
+				CoinInputsIndex: 0,
+				ItemIds:         nil,
+			},
+			changeExcutionCreator: false,
+			valid:                 false,
+		},
+		{
+			decs:                "Valid",
+			cookbook:            *cookbook,
+			unEnabledCookbook:   false,
+			changeIdCookbook:    false,
+			recipe:              *recipe,
+			changeIdRecipe:      false,
+			updateCoinInputs:    false,
+			updateEntriesRecipe: false,
+			execution: types.MsgExecuteRecipe{
+				Creator:         types.TestCreator,
+				CookbookId:      "",
+				RecipeId:        "",
+				CoinInputsIndex: 0,
+				ItemIds:         nil,
+			},
+			changeExcutionCreator: false,
+			valid:                 true,
+		},
+	} {
+		suite.Run(tc.decs, func() {
+
+			// Start check/config params
+
+			if tc.unEnabledCookbook {
+				tc.cookbook.Enabled = false
+			} else {
+				tc.cookbook.Enabled = true
+			}
+
+			tc.cookbook.Id = fmt.Sprintf("%d", index)
+			tc.recipe.Id = fmt.Sprintf("%d", index)
+
+			// Check change Id for Cookbook
+			if tc.changeIdCookbook {
+				tc.execution.CookbookId = fmt.Sprintf("%d", index) + "test"
+			} else {
+				tc.execution.CookbookId = fmt.Sprintf("%d", index)
+			}
+
+			// Check change Id for Receipt
+			if tc.changeIdRecipe {
+				tc.execution.RecipeId = fmt.Sprintf("%d", index) + "test"
+			} else {
+				tc.execution.RecipeId = fmt.Sprintf("%d", index)
+			}
+
+			tc.recipe.CookbookId = tc.cookbook.Id
+
+			//check Update CoinInputs of recipe
+			if tc.updateCoinInputs {
+				tc.recipe.CoinInputs = []types.CoinInput{{
+					Coins: sdk.NewCoins(
+						sdk.NewCoin(types.PylonsCoinDenom, sdk.NewInt(10)),
+					),
+				}}
+			} else {
+				tc.recipe.CoinInputs = nil
+			}
+
+			//check Update Entries of recipe and setup PaymentInfos
+			if tc.updateEntriesRecipe && tc.execution.PaymentInfos != nil {
+				params := k.GetParams(suite.ctx)
+				params.PaymentProcessors = append(params.PaymentProcessors, types.PaymentProcessor{
+					CoinDenom:            types.PylonsCoinDenom,
+					PubKey:               base64.StdEncoding.EncodeToString(privKey.PubKey().Bytes()),
+					ProcessorPercentage:  types.DefaultProcessorPercentage,
+					ValidatorsPercentage: types.DefaultValidatorsPercentage,
+					Name:                 "TestPayment",
+				})
+				k.SetParams(suite.ctx, params)
+			} else if tc.updateEntriesRecipe {
+				tc.recipe.Entries.ItemOutputs = []types.ItemOutput{
+					{
+						Quantity:     10,
+						AmountMinted: 10,
+					},
+				}
+			} else {
+				tc.recipe.Entries.ItemOutputs = nil
+			}
+
+			// check change Execution Creator of execution
+			if tc.changeExcutionCreator {
+				tc.execution.Creator = creator
+			}
+			// End check/config params
+
+			//Create Cookbook
+			_, err := srv.CreateCookbook(wctx, &tc.cookbook)
+			require.NoError(err)
+
+			if tc.changeIdRecipe {
+				tc.recipe.Id = tc.recipe.Id + fmt.Sprintf("%d", index)
+			}
+			// Create Recipe
+			_, err = srv.CreateRecipe(wctx, &tc.recipe)
+			require.NoError(err)
+			rst, found := k.GetRecipe(ctx, tc.recipe.CookbookId, tc.recipe.Id)
+			require.True(found)
+			require.Equal(tc.recipe.Id, rst.Id)
+
+			// run test cases
+			_, err = srv.ExecuteRecipe(wctx, &tc.execution)
+			if tc.valid {
+				suite.Require().NoError(err)
+				completed, pending := k.GetAllExecutionByRecipe(ctx, tc.recipe.CookbookId, tc.recipe.Id)
+				require.Equal(0, len(completed))
+				require.Equal(1, len(pending))
+				types.UpdateAppCheckFlagTest(types.FlagFalse)
+			} else {
+				suite.Require().Error(err)
+			}
+		})
+	}
 }
 
 func (suite *IntegrationTestSuite) TestMatchItemInputsForExecution() {

--- a/x/pylons/keeper/msg_server_execute_recipe_test.go
+++ b/x/pylons/keeper/msg_server_execute_recipe_test.go
@@ -260,7 +260,7 @@ func (suite *IntegrationTestSuite) TestExecuteRecipe2() {
 			valid:                 false,
 		},
 		{
-			decs:                "Error lock coins for execution",
+			decs:                "Error locking coins for execution",
 			cookbook:            *cookbook,
 			unEnabledCookbook:   false,
 			changeIdCookbook:    false,
@@ -279,7 +279,7 @@ func (suite *IntegrationTestSuite) TestExecuteRecipe2() {
 			valid:                 false,
 		},
 		{
-			decs:                "User account username not found",
+			decs:                "Username not found",
 			cookbook:            *cookbook,
 			unEnabledCookbook:   false,
 			changeIdCookbook:    false,


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->
## What is the purpose of the change
   - Update test case and code for `ExecuteRecipe`
## Brief Changelog
   - Write all test cases with table-driven test and update code for `ExecuteRecipe` function
## Testing and Verifying
   - This change is a trivial rework/code cleanup without any test coverage
## Documentation and Release Note
   - Does this pull request introduces a new feature or user-facing behaviour changes? no 
   - How is the feature or change documented? not applicable
## Take note 
   - About `ExecuteRecipe` function, I have changed the order of lines of code because of the logic test. As may you can see, in the older version of the code, if you want to get `found` in `cookbook, found := k.GetCookbook(ctx, msg.CookbookId)` is false, you have to pass `recipe, found := k.GetRecipe(ctx, msg.CookbookId, msg.RecipeId)` before, but pass this line it mean `found` in `cookbook, found := k.GetCookbook(ctx, msg.CookbookId)` have to true, it's conflict right? . Everything will ok when change the order of them in my commit
## Notional-labs
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---
