### PR TITLE
day 1 of dogfooding hotfixes

### DIFF
--- a/cmd/pylonsd/cmd/dev.go
+++ b/cmd/pylonsd/cmd/dev.go
@@ -85,18 +85,22 @@ func loadModuleFromPath(modulePath string, currentPath string) string {
 }
 
 func loadModulesInline(bytes []byte, path string, info os.FileInfo, gadgets *[]Gadget) string {
+	// TODO: this function is slightly kludgy due to hotfixes rn - rewrite it
 	json := string(bytes)
 	lines := strings.Split(json, "\n")
 	for i, line := range lines {
-		lineTrimmed := strings.TrimLeft(line, " ")
-		if len(lineTrimmed) != 0 && lineTrimmed[0] == '#' {
-			appendComma := strings.HasSuffix(lines[i], ",")
+		line = strings.TrimSpace(line)
+		if len(line) != 0 && line[0] == '#' {
+			appendComma := strings.HasSuffix(line, ",")
+			if appendComma {
+				line = strings.TrimSuffix(line, ",")
+			}
 			if strings.Contains(line, includeDirective) {
 				modulePath := strings.TrimSpace(strings.Split(line, includeDirective)[1])
 				lines[i] = loadModuleFromPath(modulePath, strings.TrimSuffix(path, info.Name())) + "\n"
 			} else {
-				splut := gadgetParamParseRegex.FindAllString(strings.TrimSuffix(strings.TrimPrefix(lineTrimmed, "#"), ","), -1)
-				gadget := GetGadget(strings.TrimSpace(splut[0]), gadgets)
+				splut := gadgetParamParseRegex.FindAllString(strings.TrimSuffix(strings.TrimPrefix(line, "#"), ","), -1)
+				gadget := GetGadget(strings.TrimSuffix(strings.TrimSpace(splut[0]), ","), gadgets)
 				lines[i] = ExpandGadget(gadget, splut[1:])
 			}
 			if appendComma {

--- a/cmd/pylonsd/cmd/gadgets.go
+++ b/cmd/pylonsd/cmd/gadgets.go
@@ -103,7 +103,7 @@ var builtinGadgets []Gadget = []Gadget{
 				],
 				"weight": 1
 			}
-		],`,
+		]`,
 		1,
 	},
 	{
@@ -182,6 +182,9 @@ func parseGadgets(s string) ([]Gadget, error) {
 	gadgetHeader := ""
 	gadgetJSON := ""
 	for i, s := range splut {
+		if len(s) == 0 {
+			continue // skip empty lines
+		}
 		str := strings.TrimSpace(s)
 		if str[0] == '#' {
 			// this line is a header, so parse out the gadget we've built. unless this is the first gadget.
@@ -242,10 +245,11 @@ func LoadGadgetsForPath(p string) (*[]Gadget, error) {
 	}
 	var dir string
 	// refactor this to not be for/break, it's gross
+	// this logic is also v. hacky
 	for {
 		dir, _, gadgets, err = loadGadgetsForPath(searchDir, gadgets)
-		if err != nil {
-			return nil, err
+		if err != nil || dir == searchDir {
+			return gadgets, err
 		}
 		if dir != "" {
 			searchDir = dir

--- a/cmd/pylonsd/cmd/gadgets_test.go
+++ b/cmd/pylonsd/cmd/gadgets_test.go
@@ -121,7 +121,7 @@ func TestGadgets(t *testing.T) {
 				],
 				"weight": 1
 			}
-		],`
+		]`
 		gadget := GetGadget("solo_output", &builtinGadgets)
 		assert.EqualValues(t, expected, ExpandGadget(gadget, []string{"grumble"}))
 	})


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Hotfixes for logic errors in devtool functionality exposed while working w/ the recipes for the demo app.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)