### PR TITLE
Implement a very simple command to dump parsed recipe/cookbook data

### DIFF
--- a/cmd/pylonsd/cmd/dev.go
+++ b/cmd/pylonsd/cmd/dev.go
@@ -16,6 +16,7 @@ import (
 )
 
 var Out io.Writer = os.Stdout // modified during testing
+var Verbose = false
 
 // group 1: (whole raw string tokens encapsulated ```like this```)
 // group 2: (tokens not containing whitespace, separated by whitespace)
@@ -115,6 +116,9 @@ func loadCookbookFromPath(path string, gadgets *[]Gadget) (types.Cookbook, strin
 	var cb types.Cookbook
 
 	json := loadModulesInline(bytes, path, info, gadgets)
+	if Verbose {
+		println(json)
+	}
 	err := jsonpb.UnmarshalString(json, &cb)
 
 	return cb, json, err
@@ -126,6 +130,9 @@ func loadRecipeFromPath(path string, gadgets *[]Gadget) (types.Recipe, string, e
 	var rcp types.Recipe
 
 	json := loadModulesInline(bytes, path, info, gadgets)
+	if Verbose {
+		println(json)
+	}
 	err := jsonpb.UnmarshalString(json, &rcp)
 	return rcp, string(bytes), err
 }

--- a/cmd/pylonsd/main.go
+++ b/cmd/pylonsd/main.go
@@ -21,6 +21,7 @@ func main() {
 	rootCmd.AddCommand(pyloncmd.DevUpdate())
 	rootCmd.AddCommand(pyloncmd.Completion())
 	rootCmd.AddCommand(pyloncmd.DevCelCheck())
+	rootCmd.AddCommand(pyloncmd.DevParse())
 	removeLineBreaksInCobraArgs(rootCmd)
 
 	if err := svrcmd.Execute(rootCmd, "PYLONSD", app.DefaultNodeHome); err != nil {


### PR DESCRIPTION
…to make debugging easier in the absence of nicer data validation stuff

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

This pull request just implements a quick and dirty command to dump parsed cookbook/recipe data to the console. This is necessary because we aren't going to have better validation on gadget JSON or errors on assembled JSON any time soon; this command will make the debugging experience somewhat less miserable in the absence of those features.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)