### PR TITLE
Use DecString helpers instead of (incorrect) hardcoded conversion logic

### DIFF
--- a/dart_sdk/lib/src/types/recipe.dart
+++ b/dart_sdk/lib/src/types/recipe.dart
@@ -5,8 +5,6 @@ import '../generated/pylons/item.pb.dart' as generated;
 import '../generated/pylons/payment_info.pb.dart' as generated;
 import '../generated/pylons/recipe.pb.dart' as generated;
 
-const _PRECISION = 10;
-
 class Recipe {
   final generated.Recipe _native;
 
@@ -200,9 +198,9 @@ class ItemOutput {
 
   double getTradePercentage() {
     if (modify) {
-      return double.parse(_nativeModify!.tradePercentage) * _PRECISION;
+      return DecString.doubleFromDecString(_nativeModify!.tradePercentage);
     } else {
-      return double.parse(_native!.tradePercentage) * _PRECISION;
+      return DecString.doubleFromDecString(_native!.tradePercentage);
     }
   }
 
@@ -379,11 +377,11 @@ class DoubleInput {
   }
 
   double getMin () {
-    return double.parse(_native.minValue) / _PRECISION;
+    return DecString.doubleFromDecString(_native.minValue);
   }
 
   double getMax () {
-    return double.parse(_native.minValue) / _PRECISION;
+    return DecString.doubleFromDecString(_native.maxValue);
   }
 }
 
@@ -419,11 +417,11 @@ class DoubleWeightRange {
   }
 
   double getMin () {
-    return double.parse(_native.lower) / _PRECISION;
+    return DecString.doubleFromDecString(_native.lower);
   }
 
   double getMax () {
-    return double.parse(_native.upper) / _PRECISION;
+    return DecString.doubleFromDecString(_native.upper);
   }
 }
 


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

This fixes a couple of  wrapper functions that were still using some (incorrect!) hardcoded decimal conversion logic instead of just using our DecString helpers. No one had caught this yet, but it was definitely a _bug_, so let's fix it.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)