### PR TITLE
Emergency Fix of bonded_tokens_pool

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -683,6 +683,36 @@ func (app *PylonsApp) BeginBlocker(ctx sdk.Context, req abci.RequestBeginBlock) 
 	// 		panic(err)
 	// 	}
 	// }
+
+	// This should only run once, and afterwards the bonded_tokens_pool's balance will be automatically kept in order
+	if ctx.BlockHeight() == 1000001 {
+		ctx.Logger().Info(fmt.Sprintf("Attempting to correct bonded_tokens_pool"))
+
+		bk := app.BankKeeper
+		bonded_tokens_pool_address := sdk.MustAccAddressFromBech32("pylo1fl48vsnmsdzcv85q5d2q4z5ajdha8yu3vp7zan")
+		balance := bk.GetBalance(ctx, bonded_tokens_pool_address, "ubedrock")
+		ctx.Logger().Info(fmt.Sprintf("bonded_tokens_pools has %v", balance))
+
+		// Account currently has 1 BEDROCK
+		// There is currently 15202 BEDROCK Total Power Delegated
+		// Unclear how this became broken, but let's mint the delta and send it to the pool
+		amount := sdk.NewCoins(sdk.NewCoin("ubedrock", sdk.NewInt(15201000000)))
+		err := bk.MintCoins(ctx, "mint", amount)
+		if err != nil {
+			panic(err)
+		}
+
+		err = bk.SendCoinsFromModuleToModule(ctx, "mint", "bonded_tokens_pool", amount)
+		if err != nil {
+			panic(err)
+		}
+
+		// Double check that the balance is expected
+		balance = bk.GetBalance(ctx, bonded_tokens_pool_address, "ubedrock")
+		ctx.Logger().Info(fmt.Sprintf("bonded_tokens_pools now has %v\n", balance))
+	}
+
+
 	return app.mm.BeginBlock(ctx, req)
 }
 


### PR DESCRIPTION
After height 1000000, nodes were slashed for the first time on Pylons.

Somehow the `bonded_tokens_pool` had only 1 BEDROCK of balance, despite the fact the total voting power is 15202.

As a result the slash panicked with the following error:

```
goroutine 1 [running]:
github.com/cosmos/cosmos-sdk/x/staking/keeper.Keeper.Slash({{0x309b530, 0xc000035c20}, {0x30c4260, 0xc0014f6330}, {0x30b9280, 0xc00115fea0}, {0x7f6bf459cb98, 0xc0001918c0}, {0x30c4028, 0xc00015a648}, ...}, ...)
        github.com/cosmos/cosmos-sdk@v0.46.6/x/staking/keeper/slash.go:141 +0x1245
github.com/cosmos/cosmos-sdk/x/slashing/keeper.Keeper.HandleValidatorSignature({{_, _}, {_, _}, {_, _}, {_, _}}, {{0x30b4b78, 0xc000052088}, ...}, ...)
        github.com/cosmos/cosmos-sdk@v0.46.6/x/slashing/keeper/infractions.go:87 +0x1386
github.com/cosmos/cosmos-sdk/x/slashing.BeginBlocker({{0x30b4b78, 0xc000052088}, {0x30c7040, 0xc000d04c40}, {{0xb, 0x0}, {0xc000560970, 0x10}, 0xf4241, {0x39cfb58a, ...}, ...}, ...}, ...)
        github.com/cosmos/cosmos-sdk@v0.46.6/x/slashing/abci.go:23 +0x23d
github.com/cosmos/cosmos-sdk/x/slashing.AppModule.BeginBlock(...)
        github.com/cosmos/cosmos-sdk@v0.46.6/x/slashing/module.go:160
github.com/cosmos/cosmos-sdk/types/module.(*Manager).BeginBlock(_, {{0x30b4b78, 0xc000052088}, {0x30c7040, 0xc000d04c40}, {{0xb, 0x0}, {0xc000560970, 0x10}, 0xf4241, ...}, ...}, ...)
        github.com/cosmos/cosmos-sdk@v0.46.6/types/module/module.go:484 +0x398
github.com/Pylons-tech/pylons/app.(*PylonsApp).BeginBlocker(_, {{0x30b4b78, 0xc000052088}, {0x30c7040, 0xc000d04c40}, {{0xb, 0x0}, {0xc000560970, 0x10}, 0xf4241, ...}, ...}, ...)
        github.com/Pylons-tech/pylons/app/app.go:715 +0x61d
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).BeginBlock(_, {{0xc000e96bc0, 0x20, 0x20}, {{0xb, 0x0}, {0xc000560970, 0x10}, 0xf4241, {0x39cfb58a, ...}, ...}, ...})
        github.com/cosmos/cosmos-sdk@v0.46.6/baseapp/abci.go:183 +0x843
github.com/tendermint/tendermint/abci/client.(*localClient).BeginBlockSync(_, {{0xc000e96bc0, 0x20, 0x20}, {{0xb, 0x0}, {0xc000560970, 0x10}, 0xf4241, {0x39cfb58a, ...}, ...}, ...})
        github.com/tendermint/tendermint@v0.34.23/abci/client/local_client.go:280 +0x118
github.com/tendermint/tendermint/proxy.(*appConnConsensus).BeginBlockSync(_, {{0xc000e96bc0, 0x20, 0x20}, {{0xb, 0x0}, {0xc000560970, 0x10}, 0xf4241, {0x39cfb58a, ...}, ...}, ...})
        github.com/tendermint/tendermint@v0.34.23/proxy/app_conn.go:81 +0x55
github.com/tendermint/tendermint/state.execBlockOnProxyApp({0x30b5f60?, 0xc0012fbf20}, {0x30bdbc0, 0xc000de95f0}, 0xc000000d20, {0x30c66b8, 0xc0005da0c0}, 0xf4240?)
        github.com/tendermint/tendermint@v0.34.23/state/execution.go:307 +0x3dd
github.com/tendermint/tendermint/state.(*BlockExecutor).ApplyBlock(_, {{{0xb, 0x0}, {0xc0005206c8, 0x8}}, {0xc0005206f0, 0x10}, 0x1, 0xf4240, {{0xc0013bc080, ...}, ...}, ...}, ...)
        github.com/tendermint/tendermint@v0.34.23/state/execution.go:140 +0x171
github.com/tendermint/tendermint/consensus.(*Handshaker).replayBlock(_, {{{0xb, 0x0}, {0xc0005206c8, 0x8}}, {0xc0005206f0, 0x10}, 0x1, 0xf4240, {{0xc0013bc080, ...}, ...}, ...}, ...)
        github.com/tendermint/tendermint@v0.34.23/consensus/replay.go:503 +0x23c
github.com/tendermint/tendermint/consensus.(*Handshaker).ReplayBlocks(_, {{{0xb, 0x0}, {0xc0005206c8, 0x8}}, {0xc0005206f0, 0x10}, 0x1, 0xf4240, {{0xc0013bc080, ...}, ...}, ...}, ...)
        github.com/tendermint/tendermint@v0.34.23/consensus/replay.go:416 +0x7ae
github.com/tendermint/tendermint/consensus.(*Handshaker).Handshake(0xc001661860, {0x30c7700, 0xc0005de0d0})
        github.com/tendermint/tendermint@v0.34.23/consensus/replay.go:268 +0x3c8
github.com/tendermint/tendermint/node.doHandshake({_, _}, {{{0xb, 0x0}, {0xc0005206c8, 0x8}}, {0xc0005206f0, 0x10}, 0x1, 0xf4240, ...}, ...)
        github.com/tendermint/tendermint@v0.34.23/node/node.go:329 +0x1b8
github.com/tendermint/tendermint/node.NewNode(0xc0010f9900, {0x30b13f0, 0xc00121de00}, 0xc000099990, {0x30935c0, 0xc0013c2900}, 0x1?, 0x0?, 0xc000099cf0, {0x30b5f60, ...}, ...)
        github.com/tendermint/tendermint@v0.34.23/node/node.go:777 +0x597
github.com/cosmos/cosmos-sdk/server.startInProcess(_, {{0x0, 0x0, 0x0}, {0x30d3f10, 0xc001204570}, 0x0, {0xc001097750, 0x10}, {0x30c9e28, ...}, ...}, ...)
        github.com/cosmos/cosmos-sdk@v0.46.6/server/start.go:313 +0x7db
github.com/cosmos/cosmos-sdk/server.StartCmd.func2(0xc000fbdb00?, {0x4393e18?, 0x0?, 0x0?})
        github.com/cosmos/cosmos-sdk@v0.46.6/server/start.go:143 +0x148
github.com/spf13/cobra.(*Command).execute(0xc000fbdb00, {0x4393e18, 0x0, 0x0})
        github.com/spf13/cobra@v1.6.1/command.go:916 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0xc000efb500)
        github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.6.1/command.go:968
github.com/spf13/cobra.(*Command).ExecuteContext(...)
        github.com/spf13/cobra@v1.6.1/command.go:961
github.com/cosmos/cosmos-sdk/server/cmd.Execute(0xc000efb500?, {0x2417848, 0x7}, {0xc0001445e8, 0x13})
        github.com/cosmos/cosmos-sdk@v0.46.6/server/cmd/execute.go:36 +0x20f
main.main()
        github.com/Pylons-tech/pylons/cmd/pylonsd/main.go:26 +0x158
```

This attempts to hack together a fix, which sends 15201 BEDROCK to the bonded_tokens_pool from the multisig address.

TODO: figure out if there's a better way to correct the balance (and discover the root cause of failure)

Initial Testing appears to be promising

```
9:06PM INF burned tokens from module account amount=2000000ubedrock from=bonded_tokens_pool module=x/bank
9:06PM INF validator slashed by slash factor burned=2000000 module=x/staking slash_factor=0.010000000000000000 validator=pylovaloper15xdt5erf2pj6r90kzzy28nk66c0436zaxj2a9y
9:06PM INF validator jailed module=x/staking validator=pylovalcons1yeyszc5msg0fq9egklc8f6vl87nlf7swnf92qh
9:06PM INF slashing and jailing validator due to liveness fault height=1000001 jailed_until=2023-02-24T23:05:25Z min_height=1000000 module=x/slashing slashed=0.010000000000000000 threshold=500000 validator=pylovalcons1yeyszc5msg0fq9egklc8f6vl87nlf7swnf92qh
9:06PM INF burned tokens from module account amount=2000000ubedrock from=bonded_tokens_pool module=x/bank
9:06PM INF validator slashed by slash factor burned=2000000 module=x/staking slash_factor=0.010000000000000000 validator=pylovaloper1hfnqlqj74pfhfyj2s3pzxdh2ja64e6rad6tuac
9:06PM INF validator jailed module=x/staking validator=pylovalcons1flw3y00yltn8dkeqv682d3pcpyzlx2dhc8hyvs
9:06PM INF slashing and jailing validator due to liveness fault height=1000001 jailed_until=2023-02-24T23:05:25Z min_height=1000000 module=x/slashing slashed=0.010000000000000000 threshold=500000 validator=pylovalcons1flw3y00yltn8dkeqv682d3pcpyzlx2dhc8hyvs
9:06PM INF burned tokens from module account amount=2000000ubedrock from=bonded_tokens_pool module=x/bank
9:06PM INF validator slashed by slash factor burned=2000000 module=x/staking slash_factor=0.010000000000000000 validator=pylovaloper1kf0qjzw5y7n9kpaegslquu6l8p7upjhz9weg44
9:06PM INF validator jailed module=x/staking validator=pylovalcons12r9jxunjrc7j0djjphu8n4nsgpsv5c6m2hyupp
9:06PM INF slashing and jailing validator due to liveness fault height=1000001 jailed_until=2023-02-24T23:05:25Z min_height=1000000 module=x/slashing slashed=0.010000000000000000 threshold=500000 validator=pylovalcons12r9jxunjrc7j0djjphu8n4nsgpsv5c6m2hyupp
9:06PM INF burned tokens from module account amount=2000000ubedrock from=bonded_tokens_pool module=x/bank
9:06PM INF validator slashed by slash factor burned=2000000 module=x/staking slash_factor=0.010000000000000000 validator=pylovaloper1s36lyhw4lerk57dfgxm0q8zfcdx0yyhsjlyzfu
9:06PM INF validator jailed module=x/staking validator=pylovalcons15etpma2m97edqull68wtmecfnj6ad807ukdjfq
9:06PM INF slashing and jailing validator due to liveness fault height=1000001 jailed_until=2023-02-24T23:05:25Z min_height=1000000 module=x/slashing slashed=0.010000000000000000 threshold=500000 validator=pylovalcons15etpma2m97edqull68wtmecfnj6ad807ukdjfq
9:07PM INF executed block height=1000001 module=consensus num_invalid_txs=1 num_valid_txs=0
```