### PR TITLE
GetLastTotalPower needs to be scaled to ubedrock

### DIFF
--- a/app/fix_bonded_tokens_pool.go
+++ b/app/fix_bonded_tokens_pool.go
@@ -27,10 +27,10 @@ func (app *PylonsApp) FixBondedTokensPool(ctx sdk.Context) {
 	// There is currently 15202 BEDROCK Total Power Delegated
 	// Transferring the missing accounting from multisig to bonded_tokens_pool
 	totalPowerInBedrock := app.StakingKeeper.GetLastTotalPower(ctx)
-	totalPowerInUbedrock = totalPower.Mul(math.NewInt(1_000_000))
+	totalPowerInUbedrock := totalPowerInBedrock.Mul(math.NewInt(1_000_000))
 
 	bondeTokensPoolBalance := bk.GetBalance(ctx, bondedTokensPoolAddress, params.StakingBaseCoinUnit)
-	bondeTokensPoolDelta := totalPower.Sub(bondeTokensPoolBalance.Amount)
+	bondeTokensPoolDelta := totalPowerInUbedrock.Sub(bondeTokensPoolBalance.Amount)
 
 	bondeTokensPoolAdjustment := sdk.NewCoins(sdk.NewCoin(params.StakingBaseCoinUnit, bondeTokensPoolDelta))
 	err := bk.SendCoinsFromAccountToModule(ctx, multisigAddress, stakingtypes.BondedPoolName, bondeTokensPoolAdjustment)

--- a/app/fix_bonded_tokens_pool.go
+++ b/app/fix_bonded_tokens_pool.go
@@ -26,8 +26,8 @@ func (app *PylonsApp) FixBondedTokensPool(ctx sdk.Context) {
 	// Account currently has 1 BEDROCK
 	// There is currently 15202 BEDROCK Total Power Delegated
 	// Transferring the missing accounting from multisig to bonded_tokens_pool
-	totalPower := app.StakingKeeper.GetLastTotalPower(ctx)
-	totalPower = totalPower.Mul(math.NewInt(1_000_000))
+	totalPowerInBedrock := app.StakingKeeper.GetLastTotalPower(ctx)
+	totalPowerInUbedrock = totalPower.Mul(math.NewInt(1_000_000))
 
 	bondeTokensPoolBalance := bk.GetBalance(ctx, bondedTokensPoolAddress, params.StakingBaseCoinUnit)
 	bondeTokensPoolDelta := totalPower.Sub(bondeTokensPoolBalance.Amount)

--- a/app/fix_bonded_tokens_pool.go
+++ b/app/fix_bonded_tokens_pool.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 
+	"cosmossdk.io/math"
 	"github.com/Pylons-tech/pylons/app/params"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -26,6 +27,7 @@ func (app *PylonsApp) FixBondedTokensPool(ctx sdk.Context) {
 	// There is currently 15202 BEDROCK Total Power Delegated
 	// Transferring the missing accounting from multisig to bonded_tokens_pool
 	totalPower := app.StakingKeeper.GetLastTotalPower(ctx)
+	totalPower = totalPower.Mul(math.NewInt(1_000_000))
 
 	bondeTokensPoolBalance := bk.GetBalance(ctx, bondedTokensPoolAddress, params.StakingBaseCoinUnit)
 	bondeTokensPoolDelta := totalPower.Sub(bondeTokensPoolBalance.Amount)

--- a/app/fix_bonded_tokens_pool_test.go
+++ b/app/fix_bonded_tokens_pool_test.go
@@ -81,10 +81,10 @@ func (suite *UpgradeTestSuite) TestFixBondedTokensPool() {
 
 	// The bonded_tokens_pool should now be restored.
 	bondedTokensPoolFixed := suite.App.BankKeeper.GetBalance(suite.Ctx, bondedTokensPoolAddress, params.StakingBaseCoinUnit)
-	suite.Require().NotEqual(bondedTokensPoolBefore.Amount, bondedTokensPoolFixed.Amount)
+	suite.Require().Equal(bondedTokensPoolBefore.Amount, bondedTokensPoolFixed.Amount)
 
 	// The master wallet should now have 9
 	masterWalletBalance = suite.App.BankKeeper.GetBalance(suite.Ctx, multisigAddress, params.StakingBaseCoinUnit)
-	suite.Require().Equal(masterWalletBalance.Amount, math.NewInt(9_999_999))
+	suite.Require().Equal(masterWalletBalance.Amount, math.NewInt(9_000_000))
 
 }


### PR DESCRIPTION
This is what we expected to result in the calculation
```
 15202000000 
-    1000000
------------
 15201000000
 ```
 
 Unfortunately GetLastTotalPower does not scale to the base denom, so we ended up with:
 
 ```
        15202 
-    1000000
------------
-     984798
```

This PR scales the GetLastTotalPower by 1M, and in turn, adjusts the unit tests.