### PR TITLE
typo-Update README.md

### DIFF
--- a/big-dipper/README.md
+++ b/big-dipper/README.md
@@ -65,7 +65,7 @@ METEOR_SETTINGS=$(cat settings.json) docker-compose up
 
 It will create a packaged Node JS tarball in `Linux x86_64` architecture at `../output`. Deploy that packaged Node JS project with process manager like [PM2](https://github.com/Unitech/pm2) or [Phusion Passenger](https://www.phusionpassenger.com/library/walkthroughs/basics/nodejs/fundamental_concepts.html).
 
-You will need to have [MongoDB >= 4.x](https://docs.mongodb.com/manual/administration/install-on-linux/) installed and [setup environment variables](https://guide.meteor.com/deployment.html#environment) correctly in order run in production. For more details on how to deploy a Meteor application, please refer to the offical documentation on [Custom Deployment](https://guide.meteor.com/deployment.html#custom-deployment).
+You will need to have [MongoDB >= 4.x](https://docs.mongodb.com/manual/administration/install-on-linux/) installed and [setup environment variables](https://guide.meteor.com/deployment.html#environment) correctly in order run in production. For more details on how to deploy a Meteor application, please refer to the official documentation on [Custom Deployment](https://guide.meteor.com/deployment.html#custom-deployment).
 
 ### Docker builds
 


### PR DESCRIPTION
# Fix: Corrected typo in README file

## Changes
- `big-dipper/README.md:68`: "offical" corrected to "official".

## Purpose
- Improved documentation accuracy and ensured professionalism by fixing the typo.
