### PR TITLE
Fix Typos and Clarify Comments in Distribution Tests and Spec Docs

### DIFF
--- a/x/pylons/keeper/distribution_test.go
+++ b/x/pylons/keeper/distribution_test.go
@@ -266,7 +266,7 @@ func (suite *IntegrationTestSuite) TestGetRewardsDistributionPercentages() {
 	k.ActualizeExecution(ctx, execution)
 
 	// verify execution completion and that requester has no balance left,
-	// also pay and fee are transfered to cookbook owner and fee collector module
+	// also pay and fee are transferred to cookbook owner and fee collector module
 	_ = bk.SpendableCoins(ctx, sdk.MustAccAddressFromBech32(executor))
 	_ = bk.SpendableCoins(ctx, sdk.MustAccAddressFromBech32(creator))
 	_ = bk.SpendableCoins(ctx, feeCollectorAddr)
@@ -416,7 +416,7 @@ func (suite *IntegrationTestSuite) TestCalculateDelegatorsRewards() {
 	k.ActualizeExecution(ctx, execution)
 
 	// verify execution completion and that requester has no balance left,
-	// also pay and fee are transfered to cookbook owner and fee collector module
+	// also pay and fee are transferred to cookbook owner and fee collector module
 	_ = bk.SpendableCoins(ctx, sdk.MustAccAddressFromBech32(executor))
 	_ = bk.SpendableCoins(ctx, sdk.MustAccAddressFromBech32(creator))
 	_ = bk.SpendableCoins(ctx, feeCollectorAddr)

--- a/x/pylons/spec/03_messages.md
+++ b/x/pylons/spec/03_messages.md
@@ -331,7 +331,7 @@ The message handling should fail if:
 Items can be sent from one account to another using the following `Msg` if the `creator` has enough balance to cover
 all of the `item.transferFee` fields of each specified `Item`.
 
-The `reciever` string field MUST be a valid Cosmos SDK address with the "pylo" prefix.
+The `receiver` string field MUST be a valid Cosmos SDK address with the "pylo" prefix.
 
 ```protobuf
 message MsgSendItems {


### PR DESCRIPTION


---


**Description:**  
- Corrected typos in comments and documentation (`transferred`, `receiver`).
- Improved clarity of comments in distribution test cases.

---